### PR TITLE
Feat/keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,33 +37,7 @@ git clone <repository-url>
 cd terraform-ja
 ```
 
-### 2. Generate SSH Key Pair
-
-Generate a new SSH key pair for accessing EC2 instances:
-
-```bash
-ssh-keygen -t rsa -b 2048 -f /home/<YOUR_USER>/<DIRECTORY>/deployer-key
-```
-
-Replace `<YOUR_USER>` and `<DIRECTORY>` with your actual username and project directory path.
-
-This command will create:
-- `deployer-key` (private key) - used for SSH access
-- `deployer-key.pub` (public key) - referenced in Terraform configuration
-
-**Important**: After generating the key pair, you need to update the `public_key` value in `keypair.tf` with the contents of your newly generated `deployer-key.pub` file.
-
-### 3. Copy Private Key to Bastion Host (Optional)
-
-If you're using a bastion host architecture, copy the private key to your bastion host:
-
-```bash
-scp -i deployer-key deployer-key ubuntu@<YOUR_BASTION_IP>:/home/ubuntu/
-```
-
-Replace `<YOUR_BASTION_IP>` with your actual bastion host IP address. This allows you to SSH from the bastion host to private instances in your VPC.
-
-### 4. Initialize Terraform
+### 2. Initialize Terraform
 
 ```bash
 terraform init
@@ -75,13 +49,13 @@ terraform init
 terraform plan
 ```
 
-### 5. Plan the Deployment
+### 4. Plan the Deployment
 
 ```bash
 terraform plan
 ```
 
-### 6. Apply the Configuration
+### 5. Apply the Configuration
 
 ```bash
 terraform apply
@@ -89,7 +63,7 @@ terraform apply
 
 Type `yes` when prompted to confirm the deployment.
 
-### 7. Access Your Infrastructure
+### 6. Access Your Infrastructure
 
 After successful deployment, you can access your EC2 instances using the SSH key:
 

--- a/alb.tf
+++ b/alb.tf
@@ -105,14 +105,3 @@ resource "aws_lb_listener" "app_listener" {
     Name = "demo-app-listener"
   }
 }
-
-# Output the ALB DNS name
-output "alb_dns_name" {
-  description = "DNS name of the load balancer"
-  value       = aws_lb.app_lb.dns_name
-}
-
-output "alb_zone_id" {
-  description = "The canonical hosted zone ID of the load balancer"
-  value       = aws_lb.app_lb.zone_id
-}

--- a/instance.tf
+++ b/instance.tf
@@ -6,15 +6,19 @@ resource "aws_instance" "bastion" {
   vpc_security_group_ids = [aws_security_group.bastion_sg.id]
   subnet_id              = aws_subnet.public-subnet-1.id # ใช้ subnet ที่สร้างใน VPC
 
-  depends_on = [aws_internet_gateway.gw]
+  depends_on = [aws_internet_gateway.gw, local_file.deployer_key]
 
-  # user_data = <<-EOF
-  #             #!/bin/bash
-  #             sudo apt update 
-  #             sudo apt install -y apache2
-  #             sudo systemctl start apache2
-  #             sudo systemctl enable apache2
-  #           EOF
+  provisioner "local-exec" {
+    command = <<EOT
+      echo "hi"
+      # Set the permissions on the private key
+      chmod 600 ${local_file.deployer_key.filename}
+      
+      # SCP the private key to the Bastion Host
+      sleep 15
+      scp -o StrictHostKeyChecking=no -i ${local_file.deployer_key.filename} ${local_file.deployer_key.filename} ubuntu@${aws_instance.bastion.public_ip}:/home/ubuntu/
+    EOT
+  }
   tags = {
     Name = "bastion"
   }

--- a/keypair.tf
+++ b/keypair.tf
@@ -1,4 +1,14 @@
+resource "tls_private_key" "rsa" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 resource "aws_key_pair" "deployer" {
   key_name   = "deployer-key"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDp9KhUOjuoivK34wH0ZRtQYGPkaHPl3JTCEJZMdNijzwaRfulPNLanB4qjSLP2vDUhw21CAS6O8su/x7rbj/Xl+oUuw/w5EZ6ud0H4KJkj2n9wjS1ihEopAoRZUXhvzebGLu2rhgzv+aLibPWAxX23sqdAThXsDUV5KVs7euh32gUdaSPJ+NHHiK+I3SLw1+5/PpiMlyq6FbCtZ7vOvDUYbuIqrqxqdvkvNIMrGn10uf2vS8A9I5H0Ms/CvVQiddM3vjYeFQtBSdvHy2TDMse5Q5GEvIJQOmghYlCGs5wVb4cAlpcYK0acHOCrL23A+6EIYhySV3aqQIb/dgpcpHht kemkai@LAPTOP-VBL1QAI4"
+  public_key = tls_private_key.rsa.public_key_openssh
+}
+
+resource "local_file" "deployer_key" {
+  content  = tls_private_key.rsa.private_key_pem
+  filename = "deployer-key.pem"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,15 @@
+output "bastion_public_ip" {
+  value = aws_instance.bastion.public_ip
+}
+
+
+# Output the ALB DNS name
+output "alb_dns_name" {
+  description = "DNS name of the load balancer"
+  value       = aws_lb.app_lb.dns_name
+}
+
+output "alb_zone_id" {
+  description = "The canonical hosted zone ID of the load balancer"
+  value       = aws_lb.app_lb.zone_id
+}


### PR DESCRIPTION
This pull request automates the SSH key pair generation and provisioning process for EC2 access, streamlines the deployment steps in the documentation, and improves the management of output variables. The most significant changes include generating SSH keys via Terraform, automatically copying the private key to the bastion host, and reorganizing output definitions.

**Infrastructure Automation:**

* Added a `tls_private_key` resource to generate an RSA key pair and a `local_file` resource to save the private key as `deployer-key.pem`, removing the need for manual SSH key generation. The `aws_key_pair` resource now uses the generated public key. (`keypair.tf`)
* Updated the bastion host instance to depend on the generated private key and added a `local-exec` provisioner to automatically copy the private key to the bastion host using SCP after creation. (`instance.tf`)

**Documentation Updates:**

* Simplified the `README.md` setup instructions by removing manual SSH key generation and bastion host key copying steps, reflecting the new automation. Step numbers were updated accordingly. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R66)

**Output Management:**

* Moved ALB DNS name and zone ID outputs from `alb.tf` to a centralized `output.tf` file and added an output for the bastion host's public IP. (`alb.tf`, `output.tf`) [[1]](diffhunk://#diff-11abf8af41716a0cfc0e543d17eeab3843eeafc9322e3129cd361c372cb8bfdfL108-L118) [[2]](diffhunk://#diff-d198a7806a6d934073bbf32ec6cc45d99aaac1e0ae9b1d46055ab433621e2035R1-R15)